### PR TITLE
Configure frontend service in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,10 +33,12 @@ services:
     ports:
       - "5173:5173"
     volumes:
-      - ./backend:/app          # <-- МОНТИРУЕМ backend, а не ./frontend
+      - ./frontend:/app
       - /app/node_modules
     working_dir: /app
-    command: sh -lc "npm ci || npm i && npm run dev -- --host --port 5173"
+    environment:
+      VITE_API_URL: http://nginx_server/api
+    command: sh -lc "npm ci || npm i && npm run dev -- --host 0.0.0.0 --port 5173"
 
   nginx:
     image: nginx:alpine


### PR DESCRIPTION
## Summary
- mount frontend code into the frontend container
- expose Laravel API URL to Vite frontend
- run dev server on 0.0.0.0:5173 during startup

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689714b1e67c8328817ed3024df50710