### PR TITLE
feat: add production docker compose and nginx config

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,41 @@
+services:
+  app:
+    build:
+      context: ./backend
+    container_name: laravel_app
+    expose:
+      - "9000"
+    volumes:
+      - ./backend:/var/www
+    depends_on:
+      - mysql
+    command: ["php-fpm"]
+
+  mysql:
+    image: mysql:8
+    container_name: mysql_db
+    restart: always
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_DATABASE: task_db
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_USER: user
+      MYSQL_PASSWORD: secret
+    volumes:
+      - db_data:/var/lib/mysql
+
+  nginx:
+    image: nginx:alpine
+    container_name: nginx_server
+    ports:
+      - "80:80"
+    volumes:
+      - ./backend:/var/www
+      - ./frontend/dist:/var/www/frontend
+      - ./nginx/default.prod.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - app
+
+volumes:
+  db_data:

--- a/nginx/default.prod.conf
+++ b/nginx/default.prod.conf
@@ -1,0 +1,36 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /var/www/frontend;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api {
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, PATCH, DELETE, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept, Authorization, X-Requested-With' always;
+
+        if ($request_method = OPTIONS) {
+            return 204;
+        }
+
+        alias /var/www/public;
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        root /var/www/public;
+        include fastcgi_params;
+        fastcgi_pass app:9000;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $request_filename;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}


### PR DESCRIPTION
## Summary
- add docker-compose setup for production with built SPA and backend API
- add production nginx config with static SPA root, `/api` routing to app, and CORS headers

## Testing
- `npm run lint`
- `npm run test:unit -- --run`
- `npm run build`
- `composer install --ignore-platform-reqs` *(failed: GitHub 403, backend dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_b_689714b326a483289bffec0389d6ec58