### PR TITLE
fix login view missing me ref

### DIFF
--- a/frontend/src/views/LoginVue.vue
+++ b/frontend/src/views/LoginVue.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref } from 'vue'
-const email = ref(''); const password = ref(''); const error = ref(null); const loading = ref(false)
+const email = ref(''); const password = ref(''); const error = ref(null); const loading = ref(false); const me = ref(null)
 
 const getXsrf = () => {
   const c = document.cookie.split('; ').find(v => v.startsWith('XSRF-TOKEN='))


### PR DESCRIPTION
## Summary
- declare `me` ref in login view to avoid undefined variable in template

## Testing
- `npm run build`
- `npm run test:unit -- --run` *(fails: injection "Symbol(router view location)" not found)*

------
https://chatgpt.com/codex/tasks/task_b_68977dcc44fc83288894bb20e917fe64