### PR TITLE
fix login route handling

### DIFF
--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -4,10 +4,10 @@ use App\Http\Controllers\Auth\AuthenticatedSessionController;
 use App\Http\Controllers\Auth\RegisteredUserController;
 use Illuminate\Http\Request;
 
-// API аутентификация под /api
-Route::post('/api/register', [RegisteredUserController::class, 'store'])->middleware('guest');
-Route::post('/api/login',    [AuthenticatedSessionController::class, 'store'])->middleware('guest');
-Route::post('/api/logout',   [AuthenticatedSessionController::class, 'destroy'])->middleware('auth:sanctum');
+// Аутентификация
+Route::post('/register', [RegisteredUserController::class, 'store'])->middleware('guest');
+Route::post('/login',    [AuthenticatedSessionController::class, 'store'])->middleware('guest');
+Route::post('/logout',   [AuthenticatedSessionController::class, 'destroy'])->middleware('auth:sanctum');
 
 // Текущий пользователь
 Route::middleware('auth:sanctum')->get('/api/user', function (Request $request) {

--- a/frontend/src/views/LoginVue.vue
+++ b/frontend/src/views/LoginVue.vue
@@ -14,7 +14,7 @@ async function login() {
   try {
     await fetch('/sanctum/csrf-cookie', { method:'GET', credentials:'include', headers:{'X-Requested-With':'XMLHttpRequest'} })
 
-    const res = await fetch('/api/login', {                // <— ВАЖНО: /api/login
+    const res = await fetch('/login', {
       method: 'POST',
       credentials: 'include',
       headers: {
@@ -28,7 +28,7 @@ async function login() {
 
     if (!(res.status === 204 || res.ok)) {
       let msg = 'Ошибка входа'
-      try { msg = (await res.clone().json()).message || msg } catch {}
+      try { msg = (await res.clone().json()).message || msg } catch { /* ignore */ }
       throw new Error(msg)
     }
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -29,6 +29,18 @@ export default defineConfig(({ mode }) => {
           target: apiUrl,
           changeOrigin: true,
         },
+        '/login': {
+          target: apiUrl,
+          changeOrigin: true,
+        },
+        '/logout': {
+          target: apiUrl,
+          changeOrigin: true,
+        },
+        '/register': {
+          target: apiUrl,
+          changeOrigin: true,
+        },
         '/sanctum': {
           target: apiUrl,
           changeOrigin: true,


### PR DESCRIPTION
## Summary
- route login requests through `/login` instead of `/api/login`
- proxy auth endpoints to backend
- expose auth routes in backend

## Testing
- `npm run test:unit -- --run` *(fails: injection "Symbol(router view location)" not found)*
- `npm run lint`
- `php -l backend/routes/web.php`
- `composer install` *(fails: Failed to download symfony/deprecation-contracts: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_689787f96f9483288aca017df3e1c80e