### PR TITLE
chore: use nginx for dev proxy

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -24,11 +24,11 @@ export default defineConfig(({ mode }) => {
       strictPort: true,
       hmr: { host: hmrHost, port: hmrPort, protocol: hmrProtocol },
       proxy: {
-        '/api': 'http://localhost', // Laravel контейнер
-        '/login': 'http://localhost',
-        '/logout': 'http://localhost',
-        '/sanctum': 'http://localhost',
-        '/user': 'http://localhost'
+        '/api': apiUrl, // Laravel контейнер
+        '/login': apiUrl,
+        '/logout': apiUrl,
+        '/sanctum': apiUrl,
+        '/user': apiUrl
       },
     },
   }


### PR DESCRIPTION
## Summary
- point Vite dev proxy to nginx container

## Testing
- `npm run lint` *(fails: Component name "user" should always be multi-word)*
- `npm run test:unit` *(fails: expected 'Tasker' to contain 'You did it!')*
- `docker compose restart frontend` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_b_6899cd8345c48328a925e59a46d6f635