### PR TITLE
fix: use /login route in frontend

### DIFF
--- a/frontend/src/__tests__/App.spec.js
+++ b/frontend/src/__tests__/App.spec.js
@@ -8,7 +8,7 @@ describe('App', () => {
   it('renders routed view under navbar', async () => {
     vi.spyOn(auth, 'getUser').mockResolvedValue()
 
-    router.push('/auth')
+    router.push('/login')
     await router.isReady()
 
     const wrapper = mount(App, {

--- a/frontend/src/auth.js
+++ b/frontend/src/auth.js
@@ -29,7 +29,7 @@ export async function login(email, password) {
   await getCsrf()
   const xsrf = getCookie('XSRF-TOKEN')
 
-  const res = await fetch('/auth', {
+  const res = await fetch('/login', {
     method: 'POST',
     credentials: 'include',
     headers: {


### PR DESCRIPTION
## Summary
- replace hardcoded `/auth` login endpoint with `/login`
- update unit test to use `/login` route

## Testing
- `npm run lint` *(fails: Component name "user" should always be multi-word, etc.)*
- `npm run test:unit -- --run`


------
https://chatgpt.com/codex/tasks/task_b_689b67438d648328a0ac7e075e7c6c45