### PR TITLE
Handle missing auth route and API error handling

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -6,6 +6,7 @@ const router = createRouter({
   routes: [
     { path: '/', redirect: '/login' },
     { path: '/login', name: 'login', component: LoginView },
+    { path: '/auth', redirect: '/login' },
     {
       path: '/dashboard',
       name: 'dashboard',
@@ -29,7 +30,9 @@ router.beforeEach(async (to, from, next) => {
       headers: { Accept: 'application/json' }
     })
     if (res.ok) return next()
-  } catch (_) {}
+  } catch {
+    // ignore
+  }
   next('/login')
 })
 

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -8,6 +8,8 @@
       <button type="submit">Добавить</button>
     </form>
 
+    <p v-if="error" class="error">{{ error }}</p>
+
     <ul>
       <li v-for="task in tasks" :key="task.id">
         <span v-if="!task.editing">{{ task.title }} — {{ task.description }}</span>
@@ -30,30 +32,61 @@ import axios from '@/axios' // твой файл с конфигом axios
 
 const tasks = ref([])
 const newTask = ref({ title: '', description: '' })
+const error = ref('')
 
 async function fetchTasks() {
-  const { data } = await axios.get('/api/tasks')
-  tasks.value = data.map(t => ({ ...t, editing: false }))
+  error.value = ''
+  try {
+    const { data } = await axios.get('/api/tasks')
+    tasks.value = data.map(t => ({ ...t, editing: false }))
+  } catch (e) {
+    console.error(e)
+    error.value = 'Не удалось загрузить задачи'
+  }
 }
 
 async function addTask() {
-  const { data } = await axios.post('/api/tasks', newTask.value)
-  tasks.value.push({ ...data, editing: false })
-  newTask.value = { title: '', description: '' }
+  error.value = ''
+  try {
+    const { data } = await axios.post('/api/tasks', newTask.value)
+    tasks.value.push({ ...data, editing: false })
+    newTask.value = { title: '', description: '' }
+  } catch (e) {
+    console.error(e)
+    error.value = 'Не удалось добавить задачу'
+  }
 }
 
 async function updateTask(task) {
-  const { data } = await axios.put(`/api/tasks/${task.id}`, {
-    title: task.title,
-    description: task.description
-  })
-  Object.assign(task, data, { editing: false })
+  error.value = ''
+  try {
+    const { data } = await axios.put(`/api/tasks/${task.id}`, {
+      title: task.title,
+      description: task.description
+    })
+    Object.assign(task, data, { editing: false })
+  } catch (e) {
+    console.error(e)
+    error.value = 'Не удалось обновить задачу'
+  }
 }
 
 async function deleteTask(id) {
-  await axios.delete(`/api/tasks/${id}`)
-  tasks.value = tasks.value.filter(t => t.id !== id)
+  error.value = ''
+  try {
+    await axios.delete(`/api/tasks/${id}`)
+    tasks.value = tasks.value.filter(t => t.id !== id)
+  } catch (e) {
+    console.error(e)
+    error.value = 'Не удалось удалить задачу'
+  }
 }
 
 onMounted(fetchTasks)
 </script>
+
+<style>
+.error {
+  color: #d00;
+}
+</style>


### PR DESCRIPTION
## Summary
- add `/auth` redirect to router to avoid missing-route warnings
- wrap task API calls in error handling with user feedback

## Testing
- `npm run test:unit`
- `npm run lint` *(fails: Component name "user" should always be multi-word, Component name "Navbar" should always be multi-word, Duplicate key 'hmr')*


------
https://chatgpt.com/codex/tasks/task_b_689b6751b5b083288a9b76cc8a635387