### PR TITLE
feat: extend tasks with status priority and deadline

### DIFF
--- a/backend/app/Http/Controllers/TaskController.php
+++ b/backend/app/Http/Controllers/TaskController.php
@@ -16,7 +16,10 @@ class TaskController extends Controller
     {
         $validated = $request->validate([
             'title' => 'required|string|max:255',
-            'description' => 'nullable|string'
+            'description' => 'nullable|string',
+            'status' => 'required|in:backlog,todo,doing,done',
+            'priority' => 'required|in:low,normal,high,urgent',
+            'due_date' => 'nullable|date',
         ]);
 
         $task = Task::create($validated);
@@ -27,7 +30,10 @@ class TaskController extends Controller
     {
         $validated = $request->validate([
             'title' => 'required|string|max:255',
-            'description' => 'nullable|string'
+            'description' => 'nullable|string',
+            'status' => 'required|in:backlog,todo,doing,done',
+            'priority' => 'required|in:low,normal,high,urgent',
+            'due_date' => 'nullable|date',
         ]);
 
         $task->update($validated);

--- a/backend/app/Models/Task.php
+++ b/backend/app/Models/Task.php
@@ -9,5 +9,15 @@ class Task extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['title', 'description'];
+    protected $fillable = [
+        'title',
+        'description',
+        'status',
+        'priority',
+        'due_date',
+    ];
+
+    protected $casts = [
+        'due_date' => 'date',
+    ];
 }

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -5,6 +5,19 @@
     <form @submit.prevent="addTask">
       <input v-model="newTask.title" placeholder="Название задачи" required />
       <input v-model="newTask.description" placeholder="Описание" />
+      <select v-model="newTask.status" required>
+        <option value="backlog">backlog</option>
+        <option value="todo">todo</option>
+        <option value="doing">doing</option>
+        <option value="done">done</option>
+      </select>
+      <select v-model="newTask.priority" required>
+        <option value="low">low</option>
+        <option value="normal">normal</option>
+        <option value="high">high</option>
+        <option value="urgent">urgent</option>
+      </select>
+      <input type="date" v-model="newTask.due_date" />
       <button type="submit">Добавить</button>
     </form>
 
@@ -12,10 +25,26 @@
 
     <ul>
       <li v-for="task in tasks" :key="task.id">
-        <span v-if="!task.editing">{{ task.title }} — {{ task.description }}</span>
+        <span v-if="!task.editing">
+          {{ task.title }} — {{ task.description }} — {{ task.status }} —
+          {{ task.priority }} — {{ task.due_date }}
+        </span>
         <span v-else>
           <input v-model="task.title" />
           <input v-model="task.description" />
+          <select v-model="task.status">
+            <option value="backlog">backlog</option>
+            <option value="todo">todo</option>
+            <option value="doing">doing</option>
+            <option value="done">done</option>
+          </select>
+          <select v-model="task.priority">
+            <option value="low">low</option>
+            <option value="normal">normal</option>
+            <option value="high">high</option>
+            <option value="urgent">urgent</option>
+          </select>
+          <input type="date" v-model="task.due_date" />
         </span>
 
         <button v-if="!task.editing" @click="task.editing = true">✏️</button>
@@ -31,14 +60,20 @@ import { ref, onMounted } from 'vue'
 import axios from '@/axios' // твой файл с конфигом axios
 
 const tasks = ref([])
-const newTask = ref({ title: '', description: '' })
+const newTask = ref({
+  title: '',
+  description: '',
+  status: 'backlog',
+  priority: 'normal',
+  due_date: '',
+})
 const error = ref('')
 
 async function fetchTasks() {
   error.value = ''
   try {
     const { data } = await axios.get('/api/tasks')
-    tasks.value = data.map(t => ({ ...t, editing: false }))
+    tasks.value = data.map(t => ({ ...t, due_date: t.due_date || '', editing: false }))
   } catch (e) {
     console.error(e)
     error.value = 'Не удалось загрузить задачи'
@@ -48,9 +83,22 @@ async function fetchTasks() {
 async function addTask() {
   error.value = ''
   try {
-    const { data } = await axios.post('/api/tasks', newTask.value)
-    tasks.value.push({ ...data, editing: false })
-    newTask.value = { title: '', description: '' }
+    const payload = {
+      title: newTask.value.title,
+      description: newTask.value.description,
+      status: newTask.value.status,
+      priority: newTask.value.priority,
+      due_date: newTask.value.due_date || null,
+    }
+    const { data } = await axios.post('/api/tasks', payload)
+    tasks.value.push({ ...data, due_date: data.due_date || '', editing: false })
+    newTask.value = {
+      title: '',
+      description: '',
+      status: 'backlog',
+      priority: 'normal',
+      due_date: '',
+    }
   } catch (e) {
     console.error(e)
     error.value = 'Не удалось добавить задачу'
@@ -62,9 +110,15 @@ async function updateTask(task) {
   try {
     const { data } = await axios.put(`/api/tasks/${task.id}`, {
       title: task.title,
-      description: task.description
+      description: task.description,
+      status: task.status,
+      priority: task.priority,
+      due_date: task.due_date || null,
     })
-    Object.assign(task, data, { editing: false })
+    Object.assign(task, data, {
+      editing: false,
+      due_date: data.due_date || '',
+    })
   } catch (e) {
     console.error(e)
     error.value = 'Не удалось обновить задачу'


### PR DESCRIPTION
## Summary
- add status, priority and due date to Task model
- validate and persist new fields when creating or updating tasks
- show and edit status, priority and due date on the dashboard

## Testing
- `npm run test:unit`
- `composer install --no-interaction --no-progress` *(failed: Failed to clone https://github.com/doctrine/lexer.git via https, ssh protocols)*


------
https://chatgpt.com/codex/tasks/task_b_689b6f781e348328b4a6ba85e3befd3b