### PR TITLE
feat(frontend): add user registration page

### DIFF
--- a/frontend/src/auth.js
+++ b/frontend/src/auth.js
@@ -66,6 +66,33 @@ export async function login(email, password) {
   return fetchUser()
 }
 
+export async function register(name, email, password, passwordConfirmation) {
+  await getCsrf()
+  const xsrf = getCookie('XSRF-TOKEN')
+
+  const res = await fetch('/register', {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-XSRF-TOKEN': xsrf,
+    },
+    body: JSON.stringify({
+      name,
+      email,
+      password,
+      password_confirmation: passwordConfirmation,
+    }),
+  })
+
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}))
+    throw new Error(data.message || 'Не удалось зарегистрироваться')
+  }
+  return fetchUser()
+}
+
 export async function logout() {
   const xsrf = getCookie('XSRF-TOKEN')
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,11 +1,13 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import LoginView from '@/views/LoginView.vue'
+import RegisterView from '@/views/RegisterView.vue'
 
 const router = createRouter({
   history: createWebHistory(),
   routes: [
     { path: '/', redirect: '/login' },
     { path: '/login', name: 'login', component: LoginView },
+    { path: '/register', name: 'register', component: RegisterView },
     { path: '/auth', redirect: '/login' },
     {
       path: '/dashboard',

--- a/frontend/src/views/RegisterView.vue
+++ b/frontend/src/views/RegisterView.vue
@@ -1,38 +1,43 @@
-<!-- src/views/LoginVue.vue -->
+<!-- src/views/RegisterView.vue -->
 <template>
   <section style="max-width:420px;margin:64px auto;padding:24px;border-radius:16px;box-shadow:0 6px 20px rgba(0,0,0,.08)">
-    <h1 style="font-size:20px;font-weight:700;margin-bottom:16px">Вход</h1>
+    <h1 style="font-size:20px;font-weight:700;margin-bottom:16px">Регистрация</h1>
 
     <form @submit.prevent="onSubmit" style="display:grid;gap:12px">
+      <input v-model="name" type="text" placeholder="Имя" required
+             style="padding:10px;border:1px solid #ddd;border-radius:10px" />
       <input v-model="email" type="email" placeholder="Email" required
              style="padding:10px;border:1px solid #ddd;border-radius:10px" />
       <input v-model="password" type="password" placeholder="Пароль" required
              style="padding:10px;border:1px solid #ddd;border-radius:10px" />
+      <input v-model="passwordConfirm" type="password" placeholder="Пароль ещё раз" required
+             style="padding:10px;border:1px solid #ddd;border-radius:10px" />
 
       <button :disabled="loading"
               style="padding:10px;border-radius:12px">
-        {{ loading ? 'Входим…' : 'Войти' }}
+        {{ loading ? 'Регистрируем…' : 'Зарегистрироваться' }}
       </button>
 
       <p v-if="error" style="color:#d00;font-size:13px">{{ error }}</p>
     </form>
     <p style="margin-top:8px;font-size:14px;text-align:center">
-      Нет аккаунта?
-      <RouterLink to="/register">Регистрация</RouterLink>
+      Уже есть аккаунт?
+      <RouterLink to="/login">Войти</RouterLink>
     </p>
   </section>
 </template>
 
 <script setup>
 import { ref } from 'vue'
-import { useRouter, useRoute } from 'vue-router'
-import { login } from '@/auth'
+import { useRouter } from 'vue-router'
+import { register } from '@/auth'
 
 const router = useRouter()
-const route = useRoute()
 
+const name = ref('')
 const email = ref('')
 const password = ref('')
+const passwordConfirm = ref('')
 const loading = ref(false)
 const error = ref('')
 
@@ -40,11 +45,10 @@ async function onSubmit() {
   error.value = ''
   loading.value = true
   try {
-    await login(email.value, password.value)
-    const to = (route.query.redirect && String(route.query.redirect)) || '/dashboard'
-    router.replace(to)
+    await register(name.value, email.value, password.value, passwordConfirm.value)
+    router.replace('/dashboard')
   } catch (e) {
-    error.value = e?.message || 'Ошибка входа'
+    error.value = e?.message || 'Ошибка регистрации'
   } finally {
     loading.value = false
   }


### PR DESCRIPTION
## Summary
- add register function for API
- create registration view and route
- link login page to registration

## Testing
- `npm run test:unit`
- `npm run lint` *(fails: Component name "user" should always be multi-word, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_689c75a71c7483288831119b676bdc8d