### PR TITLE
feat: add semantic classes and text buttons

### DIFF
--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1,57 +1,82 @@
 <template>
-  <div>
-    <h2>Все задачи</h2>
+  <div class="dashboard">
+    <h2 class="dashboard__title">Все задачи</h2>
 
-    <p v-if="loading">Загрузка...</p>
+    <p v-if="loading" class="dashboard__loading">Загрузка...</p>
 
-    <form @submit.prevent="addTask">
-      <input v-model="newTask.title" placeholder="Название задачи" required />
-      <input v-model="newTask.description" placeholder="Описание" />
-      <select v-model="newTask.status" required>
+    <form @submit.prevent="addTask" class="task-form">
+      <input
+        v-model="newTask.title"
+        placeholder="Название задачи"
+        required
+        class="task-form__title"
+      />
+      <input
+        v-model="newTask.description"
+        placeholder="Описание"
+        class="task-form__description"
+      />
+      <select v-model="newTask.status" required class="task-form__status">
         <option value="backlog">backlog</option>
         <option value="todo">todo</option>
         <option value="doing">doing</option>
         <option value="done">done</option>
       </select>
-      <select v-model="newTask.priority" required>
+      <select v-model="newTask.priority" required class="task-form__priority">
         <option value="low">low</option>
         <option value="normal">normal</option>
         <option value="high">high</option>
         <option value="urgent">urgent</option>
       </select>
-      <input type="date" v-model="newTask.due_date" />
-      <button type="submit" :disabled="loading">{{ loading ? 'Загрузка…' : 'Добавить' }}</button>
+      <input type="date" v-model="newTask.due_date" class="task-form__due-date" />
+      <button type="submit" :disabled="loading" class="task-form__submit">
+        {{ loading ? 'Загрузка…' : 'Добавить' }}
+      </button>
     </form>
 
-    <p v-if="error" class="error">{{ error }}</p>
+    <p v-if="error" class="dashboard__error error">{{ error }}</p>
 
-    <ul>
-      <li v-for="task in tasks" :key="task.id">
-        <span v-if="!task.editing">
+    <ul class="task-list">
+      <li v-for="task in tasks" :key="task.id" class="task-item">
+        <span v-if="!task.editing" class="task-item__text">
           {{ task.title }} — {{ task.description }} — {{ task.status }} —
           {{ task.priority }} — {{ task.due_date }}
         </span>
-        <span v-else>
-          <input v-model="task.title" />
-          <input v-model="task.description" />
-          <select v-model="task.status">
+        <span v-else class="task-item__edit-fields">
+          <input v-model="task.title" class="task-item__title" />
+          <input v-model="task.description" class="task-item__description" />
+          <select v-model="task.status" class="task-item__status">
             <option value="backlog">backlog</option>
             <option value="todo">todo</option>
             <option value="doing">doing</option>
             <option value="done">done</option>
           </select>
-          <select v-model="task.priority">
+          <select v-model="task.priority" class="task-item__priority">
             <option value="low">low</option>
             <option value="normal">normal</option>
             <option value="high">high</option>
             <option value="urgent">urgent</option>
           </select>
-          <input type="date" v-model="task.due_date" />
+          <input type="date" v-model="task.due_date" class="task-item__due-date" />
         </span>
 
-        <button v-if="!task.editing" @click="task.editing = true" :disabled="loading">✏️</button>
-        <button v-else @click="updateTask(task)" :disabled="loading">💾</button>
-        <button @click="deleteTask(task.id)" :disabled="loading">🗑</button>
+        <button
+          v-if="!task.editing"
+          @click="task.editing = true"
+          :disabled="loading"
+          class="task-item__edit"
+        >Редактировать</button>
+        <button
+          v-else
+          @click="updateTask(task)"
+          :disabled="loading"
+          class="task-item__save"
+        >💾</button>
+        <button
+          @click="deleteTask(task.id)"
+          :disabled="loading"
+          class="task-item__delete"
+        >Удалить</button>
       </li>
     </ul>
   </div>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -1,24 +1,44 @@
 <!-- src/views/LoginVue.vue -->
 <template>
-  <section style="max-width:420px;margin:64px auto;padding:24px;border-radius:16px;box-shadow:0 6px 20px rgba(0,0,0,.08)">
-    <h1 style="font-size:20px;font-weight:700;margin-bottom:16px">Авторизация</h1>
+  <section
+    style="max-width:420px;margin:64px auto;padding:24px;border-radius:16px;box-shadow:0 6px 20px rgba(0,0,0,.08)"
+    class="login"
+  >
+    <h1 style="font-size:20px;font-weight:700;margin-bottom:16px" class="login__title">
+      Авторизация
+    </h1>
 
-    <form @submit.prevent="onSubmit" style="display:grid;gap:12px">
-      <input v-model="email" type="email" placeholder="Email" required
-             style="padding:10px;border:1px solid #ddd;border-radius:10px" />
-      <input v-model="password" type="password" placeholder="Пароль" required
-             style="padding:10px;border:1px solid #ddd;border-radius:10px" />
+    <form @submit.prevent="onSubmit" style="display:grid;gap:12px" class="login__form">
+      <input
+        v-model="email"
+        type="email"
+        placeholder="Email"
+        required
+        style="padding:10px;border:1px solid #ddd;border-radius:10px"
+        class="login__input login__input--email"
+      />
+      <input
+        v-model="password"
+        type="password"
+        placeholder="Пароль"
+        required
+        style="padding:10px;border:1px solid #ddd;border-radius:10px"
+        class="login__input login__input--password"
+      />
 
-      <button :disabled="loading"
-              style="padding:10px;border-radius:12px">
+      <button
+        :disabled="loading"
+        style="padding:10px;border-radius:12px"
+        class="login__submit"
+      >
         {{ loading ? 'Загрузка…' : 'Войти' }}
       </button>
 
-      <p v-if="error" style="color:#d00;font-size:13px">{{ error }}</p>
+      <p v-if="error" style="color:#d00;font-size:13px" class="login__error">{{ error }}</p>
     </form>
-    <p style="margin-top:8px;font-size:14px;text-align:center">
+    <p style="margin-top:8px;font-size:14px;text-align:center" class="login__register">
       Нет аккаунта?
-      <RouterLink to="/register">Регистрация</RouterLink>
+      <RouterLink to="/register" class="login__register-link">Регистрация</RouterLink>
     </p>
   </section>
 </template>

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -1,50 +1,68 @@
 <!-- ProfileView.vue -->
 <template>
-    <section style="max-width: 600px; margin: 32px auto; padding: 16px;">
-      <h1 style="font-size: 22px; font-weight: 700; margin-bottom: 16px;">Профиль</h1>
-  
-    <div v-if="loading">Загрузка профиля…</div>
+  <section
+    style="max-width: 600px; margin: 32px auto; padding: 16px;"
+    class="profile"
+  >
+    <h1 style="font-size: 22px; font-weight: 700; margin-bottom: 16px;" class="profile__title">
+      Профиль
+    </h1>
+
+    <div v-if="loading" class="profile__loading">Загрузка профиля…</div>
     <div v-else>
-      <div v-if="error" style="color:#d00; margin-bottom:8px;">{{ error }}</div>
-      <div v-if="user">
-          <form @submit.prevent="onSave" style="margin-bottom:8px;">
-            <div style="margin-bottom:8px;">
-              <label>
-                Имя:
-                <input v-model="form.name" type="text" />
-              </label>
-            </div>
-            <div style="margin-bottom:8px;">
-              <label>
-                Email:
-                <input v-model="form.email" type="email" />
-              </label>
-            </div>
-            <button type="submit" :disabled="saving">{{ saving ? 'Загрузка…' : 'Сохранить' }}</button>
-          </form>
+      <div v-if="error" style="color:#d00; margin-bottom:8px;" class="profile__error">{{ error }}</div>
+      <div v-if="user" class="profile__content">
+        <form @submit.prevent="onSave" style="margin-bottom:8px;" class="profile__form">
+          <div style="margin-bottom:8px;" class="profile__field">
+            <label class="profile__label">
+              Имя:
+              <input v-model="form.name" type="text" class="profile__input" />
+            </label>
+          </div>
+          <div style="margin-bottom:8px;" class="profile__field">
+            <label class="profile__label">
+              Email:
+              <input v-model="form.email" type="email" class="profile__input" />
+            </label>
+          </div>
+          <button type="submit" :disabled="saving" class="profile__save">
+            {{ saving ? 'Загрузка…' : 'Сохранить' }}
+          </button>
+        </form>
 
-          <form @submit.prevent="onSavePassword" style="margin-bottom:8px;">
-            <div style="margin-bottom:8px;">
-              <label>
-                Пароль:
-                <input v-model="passwordForm.password" type="password" />
-              </label>
-            </div>
-            <div style="margin-bottom:8px;">
-              <label>
-                Подтверждение пароля:
-                <input v-model="passwordForm.passwordConfirmation" type="password" />
-              </label>
-            </div>
-            <button type="submit" :disabled="savingPassword">{{ savingPassword ? 'Загрузка…' : 'Обновить пароль' }}</button>
-          </form>
+        <form @submit.prevent="onSavePassword" style="margin-bottom:8px;" class="profile__password-form">
+          <div style="margin-bottom:8px;" class="profile__field">
+            <label class="profile__label">
+              Пароль:
+              <input v-model="passwordForm.password" type="password" class="profile__input" />
+            </label>
+          </div>
+          <div style="margin-bottom:8px;" class="profile__field">
+            <label class="profile__label">
+              Подтверждение пароля:
+              <input v-model="passwordForm.passwordConfirmation" type="password" class="profile__input" />
+            </label>
+          </div>
+          <button type="submit" :disabled="savingPassword" class="profile__password-save">
+            {{ savingPassword ? 'Загрузка…' : 'Обновить пароль' }}
+          </button>
+        </form>
 
-          <p><strong>Создан:</strong> {{ new Date(user.created_at).toLocaleString() }}</p>
-          <button @click="onDelete" :disabled="deleting" style="margin-top:16px;color:#d00">{{ deleting ? 'Загрузка…' : 'Удалить аккаунт' }}</button>
-        </div>
+        <p class="profile__created">
+          <strong>Создан:</strong> {{ new Date(user.created_at).toLocaleString() }}
+        </p>
+        <button
+          @click="onDelete"
+          :disabled="deleting"
+          style="margin-top:16px;color:#d00"
+          class="profile__delete"
+        >
+          {{ deleting ? 'Загрузка…' : 'Удалить аккаунт' }}
+        </button>
       </div>
-      </section>
-      </template>
+    </div>
+  </section>
+</template>
 
     <script setup>
       import { ref, reactive, onMounted } from 'vue'

--- a/frontend/src/views/RegisterView.vue
+++ b/frontend/src/views/RegisterView.vue
@@ -1,28 +1,60 @@
 <!-- src/views/RegisterView.vue -->
 <template>
-  <section style="max-width:420px;margin:64px auto;padding:24px;border-radius:16px;box-shadow:0 6px 20px rgba(0,0,0,.08)">
-    <h1 style="font-size:20px;font-weight:700;margin-bottom:16px">Регистрация</h1>
+  <section
+    style="max-width:420px;margin:64px auto;padding:24px;border-radius:16px;box-shadow:0 6px 20px rgba(0,0,0,.08)"
+    class="register"
+  >
+    <h1 style="font-size:20px;font-weight:700;margin-bottom:16px" class="register__title">
+      Регистрация
+    </h1>
 
-    <form @submit.prevent="onSubmit" style="display:grid;gap:12px">
-      <input v-model="name" type="text" placeholder="Имя" required
-             style="padding:10px;border:1px solid #ddd;border-radius:10px" />
-      <input v-model="email" type="email" placeholder="Email" required
-             style="padding:10px;border:1px solid #ddd;border-radius:10px" />
-      <input v-model="password" type="password" placeholder="Пароль" required
-             style="padding:10px;border:1px solid #ddd;border-radius:10px" />
-      <input v-model="passwordConfirm" type="password" placeholder="Пароль ещё раз" required
-             style="padding:10px;border:1px solid #ddd;border-radius:10px" />
+    <form @submit.prevent="onSubmit" style="display:grid;gap:12px" class="register__form">
+      <input
+        v-model="name"
+        type="text"
+        placeholder="Имя"
+        required
+        style="padding:10px;border:1px solid #ddd;border-radius:10px"
+        class="register__input register__input--name"
+      />
+      <input
+        v-model="email"
+        type="email"
+        placeholder="Email"
+        required
+        style="padding:10px;border:1px solid #ddd;border-radius:10px"
+        class="register__input register__input--email"
+      />
+      <input
+        v-model="password"
+        type="password"
+        placeholder="Пароль"
+        required
+        style="padding:10px;border:1px solid #ddd;border-radius:10px"
+        class="register__input register__input--password"
+      />
+      <input
+        v-model="passwordConfirm"
+        type="password"
+        placeholder="Пароль ещё раз"
+        required
+        style="padding:10px;border:1px solid #ddd;border-radius:10px"
+        class="register__input register__input--password-confirm"
+      />
 
-      <button :disabled="loading"
-              style="padding:10px;border-radius:12px">
+      <button
+        :disabled="loading"
+        style="padding:10px;border-radius:12px"
+        class="register__submit"
+      >
         {{ loading ? 'Загрузка…' : 'Зарегистрироваться' }}
       </button>
 
-      <p v-if="error" style="color:#d00;font-size:13px">{{ error }}</p>
+      <p v-if="error" style="color:#d00;font-size:13px" class="register__error">{{ error }}</p>
     </form>
-    <p style="margin-top:8px;font-size:14px;text-align:center">
+    <p style="margin-top:8px;font-size:14px;text-align:center" class="register__login">
       Уже есть аккаунт?
-      <RouterLink to="/login">Войти</RouterLink>
+      <RouterLink to="/login" class="register__login-link">Войти</RouterLink>
     </p>
   </section>
 </template>


### PR DESCRIPTION
## Summary
- apply semantic naming classes across auth, profile, and task views
- replace edit/delete icons with text labels in task list

## Testing
- `npm run lint`
- `npm run test:unit -- --run`


------
https://chatgpt.com/codex/tasks/task_b_689ca8045c3c8328a57896b14f8b0640