### PR TITLE
feat: move navbar to sidebar

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,14 +1,33 @@
 <template>
   <div class="app">
-    <Navbar />
-    <router-view />
+    <Navbar v-if="showNavbar" />
+    <div class="content">
+      <router-view />
+    </div>
   </div>
 </template>
 
 <script setup>
 import Navbar from '@/components/Navbar.vue'
 import { auth } from '@/store/auth.js'
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
 
 // при загрузке проверяем авторизацию
 auth.getUser()
+
+const route = useRoute()
+const showNavbar = computed(() => !['/login', '/register'].includes(route.path))
 </script>
+
+<style>
+.app {
+  display: flex;
+}
+
+.content {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+</style>

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -27,6 +27,27 @@ async function logout() {
   await auth.logout()
   router.push('/login')
 }
-  </script>
+</script>
+
+<style scoped>
+.navbar {
+  width: 200px;
+  min-height: 100vh;
+  padding: 1rem;
+  background: #f0f0f0;
+}
+
+.navbar__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.navbar__item {
+}
+</style>
   
   


### PR DESCRIPTION
## Summary
- hide navbar on login and registration pages
- display sidebar navigation on authenticated pages with centered content

## Testing
- `npm run test:unit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689cbbbad6408328a23127360a30f8f5